### PR TITLE
gallery section complete

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -202,8 +202,60 @@ body {
     grid-column: 1 / -1; }
 
 .gallery {
-  background-color: #54483A;
-  grid-column: full-start / full-end; }
+  background-color: #f9f7f6;
+  grid-column: full-start / full-end;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(7, 5vw);
+  grid-gap: 1.5rem;
+  padding: 1.5rem; }
+  .gallery__item--1 {
+    grid-row: 1 / span 2;
+    grid-column: 1 / span 2; }
+  .gallery__item--2 {
+    grid-row: 1 / span 3;
+    grid-column: 3 / 6; }
+  .gallery__item--3 {
+    grid-row: 1 / 3;
+    grid-column: 6 / 7; }
+  .gallery__item--4 {
+    grid-row: 1 / 3;
+    grid-column: 7 / -1; }
+  .gallery__item--5 {
+    grid-row: 3 / 6;
+    grid-column: 1 / span 2; }
+  .gallery__item--6 {
+    grid-row: 4 / 6;
+    grid-column: 3 / 5; }
+  .gallery__item--7 {
+    grid-row: 4 / 5;
+    grid-column: 5 / 6; }
+  .gallery__item--8 {
+    grid-row: 3 / 5;
+    grid-column: 6 / 8; }
+  .gallery__item--9 {
+    grid-row: 3 / 6;
+    grid-column: 8 / -1; }
+  .gallery__item--10 {
+    grid-row: 6 / -1;
+    grid-column: 1 / 2; }
+  .gallery__item--11 {
+    grid-row: 6 / -1;
+    grid-column: 2 / 4; }
+  .gallery__item--12 {
+    grid-row: 6 / -1;
+    grid-column: 4 / 5; }
+  .gallery__item--13 {
+    grid-row: 5 / -1;
+    grid-column: 5 / span 3; }
+  .gallery__item--14 {
+    grid-row: 6 / -1;
+    grid-column: 8 / -1; }
+  .gallery__img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block; }
 
 .footer {
   background-color: #101d2c;

--- a/index.html
+++ b/index.html
@@ -288,7 +288,23 @@
   </section>
 
   <section class="gallery">
-    Gallery
+  
+    <figure class="gallery__item gallery__item--1"><img src="img/gal-1.jpeg" alt="Gallery image 1" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--2"><img src="img/gal-2.jpeg" alt="Gallery image 2" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--3"><img src="img/gal-3.jpeg" alt="Gallery image 3" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--4"><img src="img/gal-4.jpeg" alt="Gallery image 4" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--5"><img src="img/gal-5.jpeg" alt="Gallery image 5" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--6"><img src="img/gal-6.jpeg" alt="Gallery image 6" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--7"><img src="img/gal-7.jpeg" alt="Gallery image 7" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--8"><img src="img/gal-8.jpeg" alt="Gallery image 8" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--9"><img src="img/gal-9.jpeg" alt="Gallery image 9" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--10"><img src="img/gal-10.jpeg" alt="Gallery image 10" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--11"><img src="img/gal-11.jpeg" alt="Gallery image 11" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--12"><img src="img/gal-12.jpeg" alt="Gallery image 12" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--13"><img src="img/gal-13.jpeg" alt="Gallery image 13" class="gallery__img"></figure>
+    <figure class="gallery__item gallery__item--14"><img src="img/gal-14.jpeg" alt="Gallery image 14" class="gallery__img"></figure>
+
+
   </section>
 
   <footer class="footer">

--- a/sass/_gallery.scss
+++ b/sass/_gallery.scss
@@ -1,4 +1,88 @@
 .gallery {
-  background-color: $color-grey-dark-1;
+  background-color: $color-grey-light-1;
   grid-column: full-start / full-end;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(7, 5vw);
+  grid-gap: 1.5rem;
+  padding: 1.5rem;
+
+
+  &__item {
+    &--1 {
+      grid-row: 1 / span 2;
+      grid-column: 1 / span 2;
+    }
+
+    &--2 {
+      grid-row: 1 / span 3;
+      grid-column: 3 / 6;
+    }
+
+    &--3 {
+      grid-row: 1 / 3;
+      grid-column: 6 / 7;
+    }
+
+    &--4 {
+      grid-row: 1 / 3;
+      grid-column: 7 / -1;
+    }
+
+    &--5 {
+      grid-row: 3 / 6;
+      grid-column: 1 / span 2;
+    }
+    &--6 {
+      grid-row: 4 / 6;
+      grid-column: 3 / 5;
+    }
+    &--7 {
+      grid-row: 4 / 5;
+      grid-column: 5 / 6;
+    }
+    &--8 {
+      grid-row: 3 / 5;
+      grid-column: 6 / 8;
+    }
+
+    &--9 {
+      grid-row: 3 / 6;
+      grid-column: 8 / -1;
+    }
+
+    &--10 {
+      grid-row: 6 / -1;
+      grid-column: 1 / 2;
+    }
+
+    &--11 {
+      grid-row: 6 / -1;
+      grid-column: 2 / 4;
+    }
+
+    &--12 {
+      grid-row: 6 / -1;
+      grid-column: 4 / 5;
+    }
+
+    &--13 {
+      grid-row: 5 / -1;
+      grid-column: 5 / span 3;
+    }
+
+    &--14 {
+      grid-row: 6 / -1;
+      grid-column: 8 / -1;
+    }
+
+  }
+
+  &__img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+  }
+
 }


### PR DESCRIPTION
Setup a basic grid for the gallery section.  Introduce figure captions around each image so I could use the object-fit property to contain the image inside the grid cell, otherwise the image would overlap into adjacent cells.  

Code snipper from Emmet to create the 14 image elements:

   ` (figure.gallery__item.gallery__item--$>img.gallery__img[src="img/gal-$.jpeg"][alt="Gallery image $"])*14`